### PR TITLE
Modify for CyVerse usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repo provides the ansible playbook and role needed to install gateone.  To 
 * The GATEONE_CONFIG_REPO assumes the following files exist:
   * 10server.conf
   * 20authentication.conf
+  * 30api_keys.conf
   * 50terminal.conf
   * ssh_config_global
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
 # gateone-server-ansible
-This repo provides the ansible playbook and role needed to install gateone.  To use this with your ansible, you should link role into the roles directory.  By default, the roles directory is /etc/ansible/roles. You'll also need to define a few variables. Currently, this playbook and role assumes Ubuntu. With a little effort, other distros could be supported.
+
+This repo provides the ansible playbook and role needed to install gateone.  To use this with your ansible, you should link role into the roles directory.  By default, the roles directory is `/etc/ansible/roles`. You'll also need to define a few variables. Currently, this playbook and role assumes Ubuntu. With a little effort, other distros could be supported.
 
 ## Installation
 
-1. git clone gateone-server-ansible repo (e.g. into /opt/gateone-server-ansible)
-2. Assuming roles is in /etc/ansible/roles, ln -s /opt/gateone-server-ansbile/ /etc/ansible/roles/
+1. `git clone gateone-server-ansible` repo (e.g. into `/opt/gateone-server-ansible`)
+2. Assuming roles is in /etc/ansible/roles, `ln -s /opt/gateone-server-ansbile/ /etc/ansible/roles/`
 3. Define the host(s) into /etc/ansible/hosts (or wherever your hosts file is configured for).  The playbook assumes the server(s) are defined in the host group called "gateone-servers".
 4. Define the following variables, generally in the hosts file or group_vars:
-   * GATEONE_REPO: location of the gateone repo
-   * GATEONE_CONFIG_REPO: location of the config repo
-   * SSH_HOST_SRC: directory containing ssl certs
-   * SSH_HOST_KEY: ssl key file name
-   * SSH_HOST_CERT: ssl cert file name
-   * UFW_DO_CONFIGURE: boolean whether to configure ufw or not
-   * UFW_INCOMING_ALLOW: array of dictionary items containing ip and ports to allow incoming (each array element has an ip and port to allow incoming). UFW is executed only if UFW_DO_CONFIGURE is true
-* UFW_OUTGOING_ALLOW: array of dictionary items containing ip and ports to allow outgoing, similar to UFW_INCOMING_ALLOW. UFW is executed only if UFW_DO_CONFIGURE is true.
+   * `GATEONE_REPO`: location of the gateone repo
+   * `GATEONE_CONFIG_REPO`: location of the config repo
+   * `SSH_HOST_SRC`: directory containing ssl certs
+   * `SSH_HOST_KEY`: ssl key file name
+   * `SSH_HOST_CERT`: ssl cert file name
+   * `UFW_DO_CONFIGURE`: boolean whether to configure ufw or not
+   * `UFW_INCOMING_ALLOW`: array of dictionary items containing ip and ports to allow incoming (each array element has an ip and port to allow incoming). `ufw` is executed only if `UFW_DO_CONFIGURE` is true
+* `UFW_OUTGOING_ALLOW`: array of dictionary items containing ip and ports to allow outgoing, similar to `UFW_INCOMING_ALLOW`. `ufw` is executed only if `UFW_DO_CONFIGURE` is true.
 5. the gateone server should start after the playbook is executed, assuming the configuration is correct
 
 ## Other notes
 
-* Simple inventory files are located in the inventory_samples directory
+* Simple inventory files are located in the `inventory_samples` directory
 
-* The GATEONE_CONFIG_REPO assumes the following files exist:
+* The `GATEONE_CONFIG_REPO` assumes the following files exist:
   * 10server.conf
   * 20authentication.conf
   * 30api_keys.conf

--- a/inventory-samples/group_vars/gateone-servers
+++ b/inventory-samples/group_vars/gateone-servers
@@ -1,5 +1,6 @@
 GATEONE_REPO: "https://github.com/liftoff/GateOne.git"
 GATEONE_CONFIG_REPO: "https://github.com/somerepo/somerepo.git"
+GATEONE_USER: "jsansible"
 SSL_HOST_SRC: "/opt/gateone-certs"
 SSL_HOST_KEY: "hostname.key"
 SSL_HOST_CERT: "hostname.cer"

--- a/playbooks/gateone-server.yml
+++ b/playbooks/gateone-server.yml
@@ -1,7 +1,7 @@
 ---
 - name: this is the playbook for installing gateone
   hosts: gateone-servers
-  remote_user: jsansible
+  remote_user: "{{ GATEONE_USER }}"
   become: true
   roles:
     - gateone-install-from-source

--- a/roles/gateone-install-from-source/tasks/main.yml
+++ b/roles/gateone-install-from-source/tasks/main.yml
@@ -78,6 +78,7 @@
   with_items:
     - 10server.conf
     - 20authentication.conf
+    - 30api_keys.conf
     - 50terminal.conf
     - ssh_config_global
 

--- a/roles/gateone-install-from-source/tasks/main.yml
+++ b/roles/gateone-install-from-source/tasks/main.yml
@@ -42,11 +42,11 @@
   file: src="{{SSL_HOST_SRC}}/{{ item }}" dest="/etc/ssl/certs/{{ item }}" state=link force=yes
   with_items:
     - "{{ SSL_HOST_CERT }}"
-  notify: restart apache
+  notify: restart nginx
 
 - name: link the key file
   file: src="{{SSL_HOST_SRC}}/{{ SSL_HOST_KEY }}" dest="/etc/ssl/private/{{ SSL_HOST_KEY }}" state=link force=yes
-  notify: restart apache
+  notify: restart nginx
 
 - name: install pip packages
   pip: name="{{ item }}"


### PR DESCRIPTION
What's been done? 
- I've included the API keys (`30api_keys.conf`) so that the Authentication API can be used (which is indicated in `20authentication.conf`). 
- Made the `remote_user` configurable
- Notify `nginx` instead of _apache_
